### PR TITLE
Remove DEV workarounds for client connection

### DIFF
--- a/lib/connection-status.ts
+++ b/lib/connection-status.ts
@@ -1,14 +1,14 @@
-import clientPromise from "@/lib/mongodb";
+import { client as dbClient } from "@/lib/mongodb";
 
 export async function dbConnectionStatus() {
   if (!process.env.MONGODB_URI) {
     return "No MONGODB_URI environment variable";
   }
-  if (!clientPromise) {
+  if (!dbClient) {
     return "Database client not initialized";
   }
   try {
-    const client = await clientPromise;
+    const client = await dbClient.connect();
     const db = client.db();
     const result = await db.command({ ping: 1 });
     console.log("MongoDB connection successful:", result);

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -11,20 +11,13 @@ const options: MongoClientOptions = {
   maxIdleTimeMS: 5000,
 };
 
-const client = new MongoClient(uri, options);
+export const client = new MongoClient(uri, options);
 
 // Attach the client to ensure proper cleanup on function suspension.
 // See https://vercel.com/blog/the-real-serverless-compute-to-database-connection-problem-solved
 attachDatabasePool(client);
 
-const clientPromise = client.connect();
-
 // Get the database instance for Better Auth
 export async function getDatabase(dbName?: string) {
-  const client = await clientPromise;
   return client.db(dbName || process.env.MONGODB_DB || "better-auth");
 }
-
-// Export a module-scoped MongoClient promise. By doing this in a
-// separate module, the client can be shared across functions.
-export default clientPromise;

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -1,4 +1,4 @@
-import { attachDatabasePool } from '@vercel/functions';
+import { attachDatabasePool } from "@vercel/functions";
 import { MongoClient, MongoClientOptions } from "mongodb";
 
 if (!process.env.MONGODB_URI) {
@@ -11,30 +11,13 @@ const options: MongoClientOptions = {
   maxIdleTimeMS: 5000,
 };
 
-let client: MongoClient;
-let clientPromise: Promise<MongoClient>;
+const client = new MongoClient(uri, options);
 
-if (process.env.NODE_ENV === "development") {
-  // In development mode, use a global variable so that the value
-  // is preserved across module reloads caused by HMR (Hot Module Replacement).
-  const globalWithMongo = global as typeof globalThis & {
-    _mongoClientPromise?: Promise<MongoClient>;
-  };
+// Attach the client to ensure proper cleanup on function suspension.
+// See https://vercel.com/blog/the-real-serverless-compute-to-database-connection-problem-solved
+attachDatabasePool(client);
 
-  if (!globalWithMongo._mongoClientPromise) {
-    client = new MongoClient(uri, options);
-    globalWithMongo._mongoClientPromise = client.connect();
-  }
-  clientPromise = globalWithMongo._mongoClientPromise;
-} else {
-  // In production mode, it's best to not use a global variable.
-  client = new MongoClient(uri, options);
-
-  // Attach the client to ensure proper cleanup on function suspension
-  attachDatabasePool(client);
-
-  clientPromise = client.connect();
-}
+const clientPromise = client.connect();
 
 // Get the database instance for Better Auth
 export async function getDatabase(dbName?: string) {
@@ -44,4 +27,4 @@ export async function getDatabase(dbName?: string) {
 
 // Export a module-scoped MongoClient promise. By doing this in a
 // separate module, the client can be shared across functions.
-export default clientPromise; 
+export default clientPromise;


### PR DESCRIPTION
DEV workarounds appear to be unnecessary as DEV-side port exhaustion is rare and recovers quickly.